### PR TITLE
Refactor findFiles to keep Windows paths in mind (#1)

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -176,14 +176,9 @@ export async function findFiles(
   buildDir: string,
   patterns: string[]
 ): Promise<string[]> {
-  const allFiles: string[] = [];
-
-  for (const pattern of patterns) {
-    const fullPattern = path.join(buildDir, pattern);
-    const files = await glob(fullPattern, { nodir: true });
-    allFiles.push(...files);
-  }
-
+  const globPatterns: string[] = [...new Set(patterns.map(p => path3.join(buildDir, p)))];
+  const allFiles: string[] = await glob(globPatterns, { nodir: true, windowsPathsNoEscape:true });
+  
   // Remove duplicates
   return [...new Set(allFiles)];
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -54,8 +54,8 @@ export function getVersion(): string {
   try {
     // This works in both dev and built versions
     const packageJsonPath = path.resolve(
-      new URL('.', import.meta.url).pathname,
-      '../../package.json'
+      new URL('.', import.meta.url).replace("file:///", "").pathname,
+      '../package.json'
     );
     const packageJson = require(packageJsonPath);
     return packageJson.version || 'unknown';


### PR DESCRIPTION
* Refactor findFiles to keep Windows paths in mind
* Fix package.json path resolution in getVersion